### PR TITLE
MAINT: update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ python:
 
 sphinx:
   builder: html
+  configuration: moshpit_docs/conf.py
 
 formats:
   - pdf


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/