### PR TITLE
Remove unused q2doc-amplicon-target xref

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -13,7 +13,6 @@ project:
     q2doc-api-target: https://develop.qiime2.org/en/stable/
     q2doc-usage-target: https://use.qiime2.org/en/stable/
     q2doc-library-target: https://library.qiime2.org
-    q2doc-amplicon-target: https://amplicon-docs.readthedocs.io/en/stable/
 
   plugins:
     - type: executable


### PR DESCRIPTION
I'm trying to clean xrefs up around the various documentation projects to avoid circularity. This xref is the only one that could have potentially caused an issue, but it's not used in these docs (so it's not currently a problem, but better to not have it in here).

If you'd like more info just let me know - I'm also planning to explain the approach quickly in the engineering meeting this week. 